### PR TITLE
Ability to use a full commit message

### DIFF
--- a/tasks/build_control.js
+++ b/tasks/build_control.js
@@ -188,7 +188,14 @@ module.exports = function (grunt) {
 
       grunt.log.subhead('Committing changes to ' + options.branch + '.');
       execWrap('git add -A .');
-      execWrap('git commit -m "' + message + '"');
+
+      // generate commit message
+      var commitFile = 'commitFile-' + crypto.createHash('md5').update(message).digest('hex').substring(0, 6);
+      fs.writeFileSync(commitFile, message);
+
+      execWrap('git commit --file=' + commitFile);
+
+      fs.unlinkSync(commitFile);
     }
 
     // Tag local branch


### PR DESCRIPTION
I was having a problem with `\n` characters in my commit message, because of `shelljs`.

I decided a commit message saved to a file would be best, this allows any kind of formatting.
