### PR TITLE
Streaming, instead of waiting

### DIFF
--- a/tasks/build_control.js
+++ b/tasks/build_control.js
@@ -44,10 +44,17 @@ module.exports = function (grunt) {
     // output and error handling
     // Args:
     // - command: the shell command
-    // - verbose: show output on the cli, defaults to true
-    function execWrap(command, verbose) {
-      var shellResult = shelljs.exec(command, {silent: true});
+    // - verbose: show output on the cli after execution, defaults to true
+    // - stream: stream the command, defaults to false
+    function execWrap(command, verbose, stream) {
       verbose = typeof verbose === 'undefined' ? true : verbose;
+      stream = typeof stream === 'undefined' ? false: stream;
+
+      if (stream) {
+        verbose = false;
+      }
+
+      var shellResult = shelljs.exec(command, {silent: (!stream)});
 
       if (shellResult.code === 0) {
         if (verbose) {
@@ -206,7 +213,7 @@ module.exports = function (grunt) {
     // Push branch to remote
     function gitPush () {
       grunt.log.subhead('Pushing ' + options.branch + ' to ' + options.remote);
-      execWrap('git push ' + remoteName + ' ' + options.branch);
+      execWrap('git push ' + remoteName + ' ' + options.branch, false, true);
 
       if (options.tag) {
         execWrap('git push ' + remoteName + ' ' + options.tag);


### PR DESCRIPTION
When I was pushing to heroku, I noticed there was a huge "no action" silence because of heroku's slug creation, it worried me that it wasn't working.

So here's an option to see the results in real time.
