### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ grunt.initConfig({
       options: {
         remote: 'git@heroku.com:example-heroku-webapp-1988.git',
         branch: 'master',
-        tag: pkg.version
+        tag: 'pkg.version'
       }
     },
     local: {


### PR DESCRIPTION
example was missing quotes around `pkg.version` causing following error when running grunt default task

```
Loading "Gruntfile.js" tasks...ERROR
>> ReferenceError: pkg is not defined
Warning: Task "default" not found. Use --force to continue.

Aborted due to warnings.
```
