### PR TITLE
Fix checking remote branch bug

### DIFF
--- a/tasks/build_control.js
+++ b/tasks/build_control.js
@@ -300,7 +300,7 @@ module.exports = function (grunt) {
 
       // Set up local branch
       localBranchExists = shelljs.exec('git show-ref --verify --quiet refs/heads/' + options.branch, {silent: true}).code === 0;
-      remoteBranchExists = shelljs.exec('git ls-remote --exit-code ' + remoteName + ' ' + options.remoteBranch || options.branch, {silent: true}).code === 0;
+      remoteBranchExists = shelljs.exec('git ls-remote --exit-code ' + remoteName + ' ' + (options.remoteBranch || options.branch), {silent: true}).code === 0;
 
       if (remoteBranchExists) {
         gitFetch();


### PR DESCRIPTION
Use 'options.branch' for default value of 'options.remoteBranch' while checking remote branch existence.
